### PR TITLE
add SliceableRepository

### DIFF
--- a/spar-wings-spring-data-chunk/README.md
+++ b/spar-wings-spring-data-chunk/README.md
@@ -76,6 +76,10 @@ Repository の Sliceable パラメータで自動で設定するのは、
 `ORDER BY create_at ASC, xxx_code ASC`
 ソート条件にユニークキーを含めるようにしてください(xxx_code が当該 table のユニークキーの前提です)。
 
+先頭から offset までの読み飛ばし件数が多くなることで API のパフォーマンス劣化を引き起こす可能性が高くなる為、
+部分集合の先頭から 2000 件を超えて取得できないように制限します。
+具体的には Sliceable パラメータの内容が `page_number * size + size > 2000` の場合、不正リクエストとみなし、InvalidSliceableException を throw します。
+
 ### INDEX 設計
 
 MySQL の場合、

--- a/spar-wings-spring-data-chunk/README.md
+++ b/spar-wings-spring-data-chunk/README.md
@@ -71,7 +71,7 @@ Repository の Sliceable パラメータで自動で設定するのは、
 です。
 
 ソート順は、ユニークになるように指定してください。
-例えば、`ORDER BY create_at ASC` にした場合、create_at が同じ値のレコードのソート順は不定です。
+例えば、`ORDER BY create_at ASC` にした場合、create_at が同じ値のレコードのソート順は不定の為、Sliceable で全ての値を取得することは保証できません。
 以下のように
 `ORDER BY create_at ASC, xxx_code ASC`
 ソート条件にユニークキーを含めるようにしてください(xxx_code が当該 table のユニークキーの前提です)。
@@ -95,5 +95,20 @@ WebMvcConfigurer の実装クラスで addArgumentResolvers を Override し、
 	* Slice のリクエストを受け取る場合
 
 インスタンスを add してください。
+
+イメージは以下の通りです。
+
+```java
+@Configuration
+public class WebMvcConfiguration implements WebMvcConfigurer {
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+		argumentResolvers.add(new ChunkableHandlerMethodArgumentResolver());
+		argumentResolvers.add(new SliceableHandlerMethodArgumentResolver());
+	}
+}
+```
+
 Controller の引数 Chunkable / Sliceable に `@ChunkableDefault` / `@SliceableDefault` を付与することで、
 リクエストが未指定の時に defalut 値を設定したインスタンスを生成します。

--- a/spar-wings-spring-data-chunk/README.md
+++ b/spar-wings-spring-data-chunk/README.md
@@ -78,7 +78,13 @@ Repository の Sliceable パラメータで自動で設定するのは、
 
 先頭から offset までの読み飛ばし件数が多くなることで API のパフォーマンス劣化を引き起こす可能性が高くなる為、
 部分集合の先頭から 2000 件を超えて取得できないように制限します。
-具体的には Sliceable パラメータの内容が `page_number * size + size > 2000` の場合、不正リクエストとみなし、InvalidSliceableException を throw します。
+具体的には Sliceable パラメータの内容が `page_number * size + size > 2000` の場合、不正リクエストとみなし、
+
+* Controller の引数に Sliceable を設定した時には HttpBadRequestException
+* Repository メソッド呼び出し時には InvalidSliceableException
+	* Controller の引数に Sliceable を設定しない場合はハンドリングをしてください
+
+を throw します。
 
 ### INDEX 設計
 

--- a/spar-wings-spring-data-chunk/README.md
+++ b/spar-wings-spring-data-chunk/README.md
@@ -1,0 +1,99 @@
+# spar-wings-spring-data-chunk
+
+spring-data-mirage と組み合わせて、Mirage と Spring を連携します。
+
+## SQL 発行
+
+用途によって、interface を実装します。代表的な interface は以下の通りです。
+
+* WritableRepository
+	* INSERT / UPDATE / DELETE を発行する
+* ReadableRepository
+	* SELECT 文を発行する
+	* `@Id` アノテーションを付与したカラムに対する SELECT 文を発行できます
+* ChunkableRepository
+	* Chunk 形式で結果を受け取る SELECT 文を発行する
+	* ReadableRepository も含まれます
+* SliceableRepository
+	* Slice 形式で結果を受け取る SELECT 文を発行する
+	* ReadableRepository も含まれます
+
+用意する sql ファイルは spring-data-mirage を参照してください。
+
+### Chunk とは？
+
+ある集合に対する部分集合を表すリソースです。[参考](https://d1sraz2ju3uqe4.cloudfront.net/section2/example/resource/Chunk.html)
+OFFSET を使用しないページネーションを提供します。後ろの部分集合を取得する際もレスポンスが落ちません。
+
+前提条件として `@Id` を付与したカラムで大小比較を行い、ソートを行います。
+その為、ORDER BY 句に `@Id` 以外のカラムを指定できません。
+
+### Slice とは？
+
+ある集合に対する部分集合を表すリソースです。
+OFFSET を使用するページネーションを提供します。
+
+後ろの部分集合を取得する際はレスポンスが悪化しますが ORDER BY 句に任意のカラムを指定可能です。
+
+**集合の件数が少ない、または、先頭から数ページだけ参照することでユースケースが満たせる場合に限り**こちらを使用しても構いません。
+
+Slice の時に発行する SELECT 文は以下のイメージです。
+
+```sql
+SELECT
+	*
+FROM
+	some_table
+WHERE
+	-- デフォルトの絞り込み条件制御
+	-- パラメータ有無で絞り込み条件制御
+ORDER BY
+	sort_column /*$direction*/ASC
+
+/*BEGIN*/
+LIMIT
+	/*IF offset != null*/
+	/*offset*/0,
+	/*END*/
+
+	/*IF size != null*/
+	/*size*/10
+	/*END*/
+/*END*/
+```
+
+Repository の Sliceable パラメータで自動で設定するのは、
+
+* `offset`
+* `size`
+* `direction`
+
+です。
+
+ソート順は、ユニークになるように指定してください。
+例えば、`ORDER BY create_at ASC` にした場合、create_at が同じ値のレコードのソート順は不定です。
+以下のように
+`ORDER BY create_at ASC, xxx_code ASC`
+ソート条件にユニークキーを含めるようにしてください(xxx_code が当該 table のユニークキーの前提です)。
+
+### INDEX 設計
+
+MySQL の場合、
+`ORDER BY create_at ASC, xxx_code ASC`
+のソートに INDEX を効かせる為には、`create_at, xxx_code` の複合 INDEX が必要になります。`create_at` だけではソートに INDEX は効きません。
+また、MySQL の場合、ソート条件に ASC と DESC が混在していると INDEX が効きません。設計時に留意してください。
+(ただし、ソート対象のレコードが少ない場合は INDEX を貼っても使用されないので考慮する必要はありません)
+絞り込み条件も存在する場合、適切な INDEX 設計を実施する必要があります。
+
+## Controller で部分集合を取得するリクエストを受け取る
+
+WebMvcConfigurer の実装クラスで addArgumentResolvers を Override し、
+
+* ChunkableHandlerMethodArgumentResolver
+	* Chunk のリクエストを受け取る場合
+* SliceableHandlerMethodArgumentResolver
+	* Slice のリクエストを受け取る場合
+
+インスタンスを add してください。
+Controller の引数 Chunkable / Sliceable に `@ChunkableDefault` / `@SliceableDefault` を付与することで、
+リクエストが未指定の時に defalut 値を設定したインスタンスを生成します。

--- a/spar-wings-spring-data-chunk/build.gradle
+++ b/spar-wings-spring-data-chunk/build.gradle
@@ -11,4 +11,5 @@ dependencies {
 	
 	testCompile "com.fasterxml.jackson.core:jackson-databind"
 	testCompile "com.jayway.jsonpath:json-path-assert:2.4.0"
+	testCompile "org.skyscreamer:jsonassert:1.5.0"
 }

--- a/spar-wings-spring-data-chunk/build.gradle
+++ b/spar-wings-spring-data-chunk/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compile "org.springframework:spring-web"
 	compile "org.springframework:spring-context"
 	compileOnly "org.springframework:spring-tx"
+	compile project(":spar-wings-httpexceptions")
 	
 	testCompile "com.fasterxml.jackson.core:jackson-databind"
 	testCompile "com.jayway.jsonpath:json-path-assert:2.4.0"

--- a/spar-wings-spring-data-chunk/build.gradle
+++ b/spar-wings-spring-data-chunk/build.gradle
@@ -12,4 +12,5 @@ dependencies {
 	testCompile "com.fasterxml.jackson.core:jackson-databind"
 	testCompile "com.jayway.jsonpath:json-path-assert:2.4.0"
 	testCompile "org.skyscreamer:jsonassert:1.5.0"
+	testCompile "org.assertj:assertj-core"
 }

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/exceptions/InvalidSliceableException.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/exceptions/InvalidSliceableException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.exceptions;
+
+import lombok.NoArgsConstructor;
+
+/**
+ * 不正な Sliceable を渡した時の Exception
+ */
+@NoArgsConstructor
+@SuppressWarnings("serial")
+public class InvalidSliceableException extends RuntimeException {
+	
+	/**
+	 * インスタンスを生成する。
+	 *
+	 * @param message 例外メッセージ
+	 * @param cause 起因例外
+	 */
+	public InvalidSliceableException(String message, Throwable cause) {
+		super(message, cause);
+	}
+	
+	/**
+	 * インスタンスを生成する。
+	 *
+	 * @param message 例外メッセージ
+	 */
+	public InvalidSliceableException(String message) {
+		super(message);
+	}
+	
+	/**
+	 * インスタンスを生成する。
+	 *
+	 * @param cause 起因例外
+	 */
+	public InvalidSliceableException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/model/SlicedResources.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/model/SlicedResources.java
@@ -30,13 +30,11 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
 import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jp.xet.sparwings.spring.data.slice.Slice;
@@ -49,18 +47,14 @@ import jp.xet.sparwings.spring.data.slice.Slice;
 @ToString
 @EqualsAndHashCode
 @XmlRootElement(name = "slicedEntities")
-@NoArgsConstructor(access = AccessLevel.PACKAGE)
 public class SlicedResources<T> {
 	
 	@Getter
-	@Setter(AccessLevel.PACKAGE)
 	@XmlElement(name = "embedded")
 	@JsonProperty("_embedded")
-	@JsonInclude(JsonInclude.Include.NON_NULL)
 	private Map<String, Collection<T>> content;
 	
 	@Getter
-	@Setter(AccessLevel.PACKAGE)
 	@XmlElement(name = "page")
 	@JsonProperty("page")
 	private SliceMetadata metadata;

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/model/SlicedResources.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/model/SlicedResources.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.model;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jp.xet.sparwings.spring.data.slice.Slice;
+
+/**
+ * Slice のレスポンス.
+ * 
+ * <p>Controller のレスポンスとして使用します。</p>
+ */
+@ToString
+@EqualsAndHashCode
+@XmlRootElement(name = "slicedEntities")
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+public class SlicedResources<T> {
+	
+	@Getter
+	@Setter(AccessLevel.PACKAGE)
+	@XmlElement(name = "embedded")
+	@JsonProperty("_embedded")
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private Map<String, Collection<T>> content;
+	
+	@Getter
+	@Setter(AccessLevel.PACKAGE)
+	@XmlElement(name = "page")
+	@JsonProperty("page")
+	private SliceMetadata metadata;
+	
+	
+	/**
+	 * Creates a {@link SlicedResources} instance with {@link Slice}.
+	 * 
+	 * @param key must not be {@code null}.
+	 * @param slice The {@link Slice}
+	 * @param wrapperFunction function coverts {@code U} to {@code T}
+	 */
+	public <U> SlicedResources(String key, Slice<U> slice, Function<U, T> wrapperFunction) {
+		this(key, slice.stream()
+			.map(wrapperFunction)
+			.collect(Collectors.toList()), new SliceMetadata(slice));
+	}
+	
+	/**
+	 * Creates a {@link SlicedResources} instance with {@link Slice}.
+	 * 
+	 * @param key must not be {@code null}.
+	 * @param slice The {@link Slice}
+	 */
+	public SlicedResources(String key, Slice<T> slice) {
+		this(key, slice.getContent(), new SliceMetadata(slice));
+	}
+	
+	/**
+	 * Creates a {@link SlicedResources} instance with content collection.
+	 * 
+	 * @param key must not be {@code null}.
+	 * @param content The contents
+	 * @since 0.11
+	 */
+	public SlicedResources(String key, Collection<T> content) {
+		this(key, content, new SliceMetadata(content.size(), null, false));
+	}
+	
+	/**
+	 * Creates a {@link SlicedResources} instance with iterable and metadata.
+	 * 
+	 * @param key must not be {@code null}.
+	 * @param content must not be {@code null}.
+	 * @param metadata must not be {@code null}.
+	 * @since 0.11
+	 */
+	public SlicedResources(String key, Collection<T> content, SliceMetadata metadata) {
+		Assert.notNull(key, "The key must not be null");
+		Assert.notNull(content, "The content must not be null");
+		Assert.notNull(metadata, "The metadata must not be null");
+		this.content = Collections.singletonMap(key, content);
+		this.metadata = metadata;
+	}
+	
+	
+	/**
+	 * Value object for pagination metadata.
+	 */
+	@ToString
+	@EqualsAndHashCode
+	@AllArgsConstructor
+	@NoArgsConstructor(access = AccessLevel.PACKAGE)
+	public static class SliceMetadata {
+		
+		@XmlAttribute
+		@JsonProperty("size")
+		@Getter(onMethod = @__(@JsonIgnore))
+		private long size;
+		
+		@XmlAttribute
+		@JsonProperty("number")
+		@Getter(onMethod = @__(@JsonIgnore))
+		private Integer pageNumber;
+		
+		@XmlAttribute
+		@JsonProperty("has_next_page")
+		@Getter(onMethod = @__(@JsonIgnore))
+		private Boolean hasNextSlice;
+		
+		
+		/**
+		 * インスタンスを生成する。
+		 * 
+		 * @param slice 当該 Slice
+		 */
+		public SliceMetadata(Slice<?> slice) {
+			this(slice.getContent().size(), slice.getPageNumber(), slice.hasNext());
+		}
+	}
+}

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/repository/SliceableRepository.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/repository/SliceableRepository.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.repository.NoRepositoryBean;
 
+import jp.xet.sparwings.spring.data.exceptions.InvalidSliceableException;
 import jp.xet.sparwings.spring.data.slice.Slice;
 import jp.xet.sparwings.spring.data.slice.Sliceable;
 
@@ -39,6 +40,7 @@ public interface SliceableRepository<E, ID extends Serializable>extends Readable
 	 * @return a slice of entities
 	 * @throws DataAccessException データアクセスエラーが発生した場合
 	 * @throws NullPointerException 引数に{@code null}を与えた場合
+	 * @throws InvalidSliceableException 不正な Sliceable だった場合
 	 */
 	Slice<E> findAll(Sliceable sliceable);
 	

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/repository/SliceableRepository.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/repository/SliceableRepository.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.repository;
+
+import java.io.Serializable;
+
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.repository.NoRepositoryBean;
+
+import jp.xet.sparwings.spring.data.slice.Slice;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+/**
+ * Repository interface to retrieve slice of entities.
+ * 
+ * @param <E> the domain type the repository manages
+ * @param <ID> the type of the id of the entity the repository manages
+ */
+@NoRepositoryBean
+public interface SliceableRepository<E, ID extends Serializable>extends ReadableRepository<E, ID> {
+	
+	/**
+	 * Returns a {@link Slice} of entities meeting the slicing restriction provided in the {@code Sliceable} object.
+	 * 
+	 * @param sliceable slicing information
+	 * @return a slice of entities
+	 * @throws DataAccessException データアクセスエラーが発生した場合
+	 * @throws NullPointerException 引数に{@code null}を与えた場合
+	 */
+	Slice<E> findAll(Sliceable sliceable);
+	
+}

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/Slice.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/Slice.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.slice;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * A part of item set.
+ * @param <T> Type of item
+ */
+public interface Slice<T>extends Collection<T> {
+	
+	/**
+	 * 当該 Slice の要素取得.
+	 * @return 当該 Slice の要素
+	 */
+	List<T> getContent();
+	
+	/**
+	 * 当該 Slice の要素を Stream で取得.
+	 * @return Stream
+	 */
+	Stream<T> stream();
+	
+	/**
+	 * Slice のページ番号取得.
+	 * @return Slice のページ番号(Slice 条件が存在しない場合、null)
+	 */
+	Integer getPageNumber();
+	
+	/**
+	 * 要素を保持しているか？
+	 * @return 要素を保持している場合、true
+	 */
+	boolean hasContent();
+	
+	/**
+	 * 次の Slice が存在するか？
+	 * @return 次の Slice が存在する場合、true
+	 */
+	boolean hasNext();
+	
+	/**
+	 * 次の Slice 条件取得.
+	 * 
+	 * @return 次の Slice 条件(次の Slice が存在しない場合、null)
+	 */
+	Sliceable nextSlice();
+	
+	/**
+	 * convert.
+	 * @param converter コンバート処理.
+	 * @param <S> 変更後の型
+	 * @return convert を行った Slice
+	 */
+	<S> Slice<S> map(Converter<? super T, ? extends S> converter);
+	
+	/**
+	 * 現在の Slice 条件取得.
+	 * @return 現在の Slice 条件
+	 */
+	Sliceable getSliceable();
+}

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/SliceImpl.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/SliceImpl.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.slice;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Slice の実装.
+ * @param <T> Slice 要素の型
+ */
+@EqualsAndHashCode
+public class SliceImpl<T> implements Slice<T> {
+	
+	/** 当該 Slice の要素. */
+	@JsonProperty
+	private final List<T> content = new ArrayList<>();
+	
+	/** Slice 条件. */
+	@JsonIgnore
+	@Getter
+	private final Sliceable sliceable;
+	
+	/** 次の Slice が存在するか？ */
+	@JsonIgnore
+	@Getter
+	private final boolean hasNext;
+	
+	
+	/**
+	 * コンストラクタ.
+	 * @param content 当該 Slice の要素
+	 * @param sliceable リクエスト
+	 * @param hasNext 次の Slice が存在する場合、true
+	 */
+	public SliceImpl(List<T> content, Sliceable sliceable, boolean hasNext) {
+		Assert.notNull(content, "Content must not be null!");
+		this.content.addAll(content);
+		this.sliceable = sliceable;
+		this.hasNext = hasNext;
+	}
+	
+	@Override
+	public List<T> getContent() {
+		return Collections.unmodifiableList(content);
+	}
+	
+	@Override
+	public Stream<T> stream() {
+		return content.stream();
+	}
+	
+	@Override
+	public Integer getPageNumber() {
+		return sliceable == null ? null : sliceable.getPageNumber();
+	}
+	
+	@Override
+	public boolean hasContent() {
+		return content.isEmpty() == false;
+	}
+	
+	@Override
+	public boolean hasNext() {
+		if (sliceable == null) {
+			return false;
+		}
+		return hasNext;
+	}
+	
+	@Override
+	public Sliceable nextSlice() {
+		if (hasNext() == false) {
+			return null;
+		}
+		return new SliceRequest(sliceable.getPageNumber() + 1,
+				sliceable.getDirection(), sliceable.getMaxContentSize());
+	}
+	
+	@Override
+	public <S> Slice<S> map(Converter<? super T, ? extends S> converter) {
+		return new SliceImpl<>(getConvertedContent(converter), sliceable, hasNext);
+	}
+	
+	/**
+	 * Applies the given {@link Converter} to the content of the {@link Slice}.
+	 *
+	 * @param converter must not be {@literal null}.
+	 * @return mapped content list
+	 */
+	protected <S> List<S> getConvertedContent(Converter<? super T, ? extends S> converter) {
+		Assert.notNull(converter, "Converter must not be null!");
+		return content.stream().map(converter::convert).collect(Collectors.toList());
+	}
+	
+	// Collection
+	
+	@Override
+	public int size() {
+		return content.size();
+	}
+	
+	@Override
+	public boolean isEmpty() {
+		return content.isEmpty();
+	}
+	
+	@Override
+	public boolean contains(Object o) {
+		return content.contains(o);
+	}
+	
+	@Override
+	public Iterator<T> iterator() {
+		return content.iterator();
+	}
+	
+	@Override
+	public Object[] toArray() {
+		return content.toArray();
+	}
+	
+	@Override
+	public boolean add(T o) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean remove(Object o) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean addAll(Collection<? extends T> c) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public void clear() {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean retainAll(Collection<?> c) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean removeAll(Collection<?> c) {
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		return content.containsAll(c);
+	}
+	
+	@Override
+	public <T1> T1[] toArray(T1[] a) {
+		return content.toArray(a);
+	}
+}

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/SliceRequest.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/SliceRequest.java
@@ -28,7 +28,7 @@ public class SliceRequest implements Sliceable {
 	/** 
 	 * ページ番号. 
 	 * 
-	 * <p>1以上指定</p>
+	 * <p>0以上指定</p>
 	 */
 	private Integer pageNumber;
 	
@@ -49,6 +49,6 @@ public class SliceRequest implements Sliceable {
 		if (pageNumber == null || maxContentSize == null) {
 			return null;
 		}
-		return (pageNumber - 1) * maxContentSize;
+		return pageNumber * maxContentSize;
 	}
 }

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/SliceRequest.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/SliceRequest.java
@@ -19,11 +19,22 @@ import lombok.Value;
 
 import org.springframework.data.domain.Sort.Direction;
 
+import jp.xet.sparwings.spring.data.exceptions.InvalidSliceableException;
+
 /**
  * Basic Java Bean implementation of {@code Sliceable}.
  */
 @Value
 public class SliceRequest implements Sliceable {
+	
+	/** 
+	 * 取得可能な最大要素数.
+	 * 
+	 * <p>
+	 * この件数を超えて要素を取得することはできません。
+	 * </p>
+	 */
+	private static final int MAX_TOTAL_CONTENT_LIMIT = 2000;
 	
 	/** 
 	 * ページ番号. 
@@ -50,5 +61,20 @@ public class SliceRequest implements Sliceable {
 			return null;
 		}
 		return pageNumber * maxContentSize;
+	}
+	
+	@Override
+	public void validate() {
+		
+		if (pageNumber == null) {
+			throw new InvalidSliceableException("pageNumber must be not null.");
+		}
+		if (maxContentSize == null) {
+			throw new InvalidSliceableException("maxContentSize must be not null.");
+		}
+		
+		if (pageNumber * maxContentSize + maxContentSize > MAX_TOTAL_CONTENT_LIMIT) {
+			throw new InvalidSliceableException("Cannot get elements beyond 2000.");
+		}
 	}
 }

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/SliceRequest.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/SliceRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.slice;
+
+import lombok.Value;
+
+import org.springframework.data.domain.Sort.Direction;
+
+/**
+ * Basic Java Bean implementation of {@code Sliceable}.
+ */
+@Value
+public class SliceRequest implements Sliceable {
+	
+	/** 
+	 * ページ番号. 
+	 * 
+	 * <p>1以上指定</p>
+	 */
+	private Integer pageNumber;
+	
+	/**
+	 * ソート順.
+	 */
+	private Direction direction;
+	
+	/**
+	 * slice 辺りの最大要素数.
+	 */
+	private Integer maxContentSize;
+	
+	
+	@Override
+	public Integer getOffset() {
+		
+		if (pageNumber == null || maxContentSize == null) {
+			return null;
+		}
+		return (pageNumber - 1) * maxContentSize;
+	}
+}

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/Sliceable.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/Sliceable.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.slice;
+
+import org.springframework.data.domain.Sort.Direction;
+
+/**
+ * Abstract interface for value-based pagination information.
+ */
+public interface Sliceable {
+	
+	/**
+	 * ページ番号取得.
+	 * @return ページ番号
+	 */
+	Integer getPageNumber();
+	
+	/**
+	 * ソート順取得.
+	 * @return ソート順
+	 */
+	Direction getDirection();
+	
+	/**
+	 * slice 辺りの最大要素数取得.
+	 * @return slice 辺りの最大要素数
+	 */
+	Integer getMaxContentSize();
+	
+	/**
+	 * offset 算出.
+	 * @return offset(計算できない場合、null)
+	 */
+	Integer getOffset();
+}

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/Sliceable.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/Sliceable.java
@@ -17,6 +17,8 @@ package jp.xet.sparwings.spring.data.slice;
 
 import org.springframework.data.domain.Sort.Direction;
 
+import jp.xet.sparwings.spring.data.exceptions.InvalidSliceableException;
+
 /**
  * Abstract interface for value-based pagination information.
  */
@@ -45,4 +47,11 @@ public interface Sliceable {
 	 * @return offset(計算できない場合、null)
 	 */
 	Integer getOffset();
+	
+	/**
+	 * validate 処理.
+	 * 
+	 * @throws InvalidSliceableException 不正な Sliceable だった場合
+	 */
+	void validate();
 }

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/Slices.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/slice/Slices.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.slice;
+
+import java.util.Collections;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * Utilities about {@link Slice}.
+ * 
+ * <p>
+ * 主にテストで使用する想定です。
+ * </p>
+ */
+@UtilityClass
+public class Slices {
+	
+	/**
+	 * Empty slice shared instance.
+	 */
+	@SuppressWarnings("rawtypes")
+	public static final Slice EMPTY_SLICE = new SliceImpl<>(Collections.emptyList(), null, false);
+	
+	
+	/**
+	 * Returns a empty slice.
+	 *
+	 * @return Empty slice
+	 */
+	@SuppressWarnings("unchecked")
+	public static final <T> Slice<T> emptySlice() {
+		return EMPTY_SLICE;
+	}
+	
+}

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableDefault.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableDefault.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.web;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.data.domain.Sort.Direction;
+
+/**
+ * Annotation to set defaults when injecting a {@link jp.xet.sparwings.spring.data.slice.Sliceable} into a controller
+ * method.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface SliceableDefault {
+	
+	/**
+	 * Alias for {@link #size()}. Prefer to use the {@link #size()} method as it makes the annotation declaration more
+	 * expressive.
+	 */
+	int value() default 10;
+	
+	/**
+	 * The default-size the injected {@link jp.xet.sparwings.spring.data.chunk.Chunkable} should get if no corresponding
+	 * parameter defined in request (default is 10).
+	 */
+	int size() default 10;
+	
+	/**
+	 * The direction to sort by. Defaults to {@link Direction#ASC}.
+	 */
+	Direction direction() default Direction.ASC;
+	
+	/**
+	 * The page number. Defaults to 1.
+	 */
+	int pageNumber() default 1;
+}

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableDefault.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableDefault.java
@@ -39,7 +39,7 @@ public @interface SliceableDefault {
 	int value() default 10;
 	
 	/**
-	 * The default-size the injected {@link jp.xet.sparwings.spring.data.chunk.Chunkable} should get if no corresponding
+	 * The default-size the injected {@link jp.xet.sparwings.spring.data.slice.Sliceable} should get if no corresponding
 	 * parameter defined in request (default is 10).
 	 */
 	int size() default 10;
@@ -50,7 +50,7 @@ public @interface SliceableDefault {
 	Direction direction() default Direction.ASC;
 	
 	/**
-	 * The page number. Defaults to 1.
+	 * The page number. Defaults to 0.
 	 */
-	int pageNumber() default 1;
+	int pageNumber() default 0;
 }

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolver.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolver.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.web;
+
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jp.xet.sparwings.spring.data.slice.SliceRequest;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+/**
+ * Extracts paging information from web requests and thus allows injecting {@link Sliceable} instances into controller
+ * methods. Request properties to be parsed can be configured. Default configuration uses request parameters beginning
+ * with {@link #DEFAULT_SIZE_PARAMETER}, {@link #DEFAULT_PAGE_NUMBER_PARAMETER}
+ * {@link #DEFAULT_DIRECTION_PARAMETER}, {@link #DEFAULT_QUALIFIER_DELIMITER}.
+ */
+@Slf4j
+public class SliceableHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver { // NOPMD - cc
+	
+	private static final String INVALID_DEFAULT_PAGE_SIZE =
+			"Invalid default page size configured for method %s! Must not be less than one!";
+	
+	private static final String DEFAULT_SIZE_PARAMETER = "size";
+	
+	private static final String DEFAULT_DIRECTION_PARAMETER = "direction";
+	
+	private static final String DEFAULT_PAGE_NUMBER_PARAMETER = "page_number";
+	
+	private static final String DEFAULT_PREFIX = "";
+	
+	private static final String DEFAULT_QUALIFIER_DELIMITER = "_";
+	
+	private static final int DEFAULT_MAX_PAGE_SIZE = 2000;
+	
+	private static final int DEFAULT_PAGE_NUMBER = 1;
+	
+	static final Sliceable DEFAULT_SLICE_REQUEST = new SliceRequest(DEFAULT_PAGE_NUMBER, null, DEFAULT_MAX_PAGE_SIZE);
+	
+	
+	private static Sliceable getDefaultSliceRequestFrom(MethodParameter parameter) {
+		SliceableDefault defaults = parameter.getParameterAnnotation(SliceableDefault.class);
+		
+		if (defaults == null) {
+			throw new IllegalArgumentException("MethodParameter must have @SliceableDefault");
+		}
+		
+		int defaultPageSize = defaults.size();
+		if (defaultPageSize == 10) {
+			defaultPageSize = defaults.value();
+		}
+		
+		if (defaultPageSize < 1) {
+			Method annotatedMethod = parameter.getMethod();
+			throw new IllegalStateException(String.format(Locale.ENGLISH, INVALID_DEFAULT_PAGE_SIZE, annotatedMethod));
+		}
+		
+		return new SliceRequest(defaults.pageNumber(), defaults.direction(), defaultPageSize);
+	}
+	
+	
+	@NonNull
+	@Setter
+	@Getter(AccessLevel.PROTECTED)
+	private Sliceable fallbackSliceable = DEFAULT_SLICE_REQUEST;
+	
+	@NonNull
+	@Getter(AccessLevel.PROTECTED)
+	@Setter
+	private String sizeParameterName = DEFAULT_SIZE_PARAMETER;
+	
+	@NonNull
+	@Getter(AccessLevel.PROTECTED)
+	@Setter
+	private String directionParameterName = DEFAULT_DIRECTION_PARAMETER;
+	
+	@NonNull
+	@Getter(AccessLevel.PROTECTED)
+	@Setter
+	private String pageNumberParameterName = DEFAULT_PAGE_NUMBER_PARAMETER;
+	
+	@Getter(AccessLevel.PROTECTED)
+	private String prefix = DEFAULT_PREFIX;
+	
+	@Getter(AccessLevel.PROTECTED)
+	@Setter
+	private String qualifierDelimiter = DEFAULT_QUALIFIER_DELIMITER;
+	
+	@Getter(AccessLevel.PROTECTED)
+	@Setter
+	private int maxPageSize = DEFAULT_MAX_PAGE_SIZE;
+	
+	@Getter(AccessLevel.PROTECTED)
+	@Setter
+	private int initPageNumber = DEFAULT_PAGE_NUMBER;
+	
+	
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return Sliceable.class.equals(parameter.getParameterType());
+	}
+	
+	@Override
+	public Object resolveArgument(MethodParameter methodParameter, ModelAndViewContainer mavContainer, // NOPMD - cc
+			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception { // NOPMD - ex
+		SpringDataSliceableAnnotationUtils.assertSliceableUniqueness(methodParameter);
+		
+		String pageSizeString = webRequest.getParameter(getParameterNameToUse(sizeParameterName, methodParameter));
+		String directionString =
+				webRequest.getParameter(getParameterNameToUse(directionParameterName, methodParameter));
+		String pageNumberString =
+				webRequest.getParameter(getParameterNameToUse(pageNumberParameterName, methodParameter));
+		
+		Sliceable defaultOrFallback = getDefaultFromAnnotationOrFallback(methodParameter);
+		if (StringUtils.hasText(pageNumberString) == false
+				&& StringUtils.hasText(pageSizeString) == false
+				&& StringUtils.hasText(directionString) == false) {
+			return defaultOrFallback;
+		}
+		
+		Integer pageSize = defaultOrFallback.getMaxContentSize() != null
+				? defaultOrFallback.getMaxContentSize() : maxPageSize;
+		if (StringUtils.hasText(pageSizeString)) {
+			try {
+				pageSize = Integer.parseInt(pageSizeString);
+			} catch (NumberFormatException e) {
+				log.trace("invalid page size: {}", pageSizeString);
+			}
+		}
+		
+		// Limit lower bound
+		pageSize = pageSize < 1 ? 1 : pageSize;
+		// Limit upper bound
+		pageSize = pageSize > maxPageSize ? maxPageSize : pageSize;
+		
+		Direction direction = Direction.fromOptionalString(directionString).orElse(null);
+		
+		Integer pageNumber =
+				defaultOrFallback.getPageNumber() != null ? defaultOrFallback.getPageNumber() : DEFAULT_PAGE_NUMBER;
+		if (StringUtils.hasText(pageNumberString)) {
+			try {
+				pageNumber = Integer.parseInt(pageNumberString);
+			} catch (NumberFormatException e) {
+				log.trace("invalid page number: {}", pageNumberString);
+			}
+		}
+		return new SliceRequest(pageNumber, direction, pageSize);
+	}
+	
+	private Sliceable getDefaultFromAnnotationOrFallback(MethodParameter methodParameter) {
+		if (methodParameter.hasParameterAnnotation(SliceableDefault.class)) {
+			return getDefaultSliceRequestFrom(methodParameter);
+		}
+		
+		return fallbackSliceable;
+	}
+	
+	/**
+	 * Returns the name of the request parameter to find the {@link Sliceable} information in. Inspects the given
+	 * {@link MethodParameter} for {@link Qualifier} present and prefixes the given source parameter name with it.
+	 * 
+	 * @param source the basic parameter name.
+	 * @param parameter the {@link MethodParameter} potentially qualified.
+	 * @return the name of the request parameter.
+	 */
+	protected String getParameterNameToUse(String source, MethodParameter parameter) {
+		StringBuilder builder = new StringBuilder(prefix);
+		
+		if (parameter != null) {
+			Qualifier qualifier = parameter.getParameterAnnotation(Qualifier.class);
+			if (qualifier != null) {
+				builder.append(qualifier.value());
+				builder.append(qualifierDelimiter);
+			}
+		}
+		
+		return builder.append(source).toString();
+	}
+}

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolver.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolver.java
@@ -60,7 +60,7 @@ public class SliceableHandlerMethodArgumentResolver implements HandlerMethodArgu
 	
 	private static final int DEFAULT_MAX_PAGE_SIZE = 2000;
 	
-	private static final int DEFAULT_PAGE_NUMBER = 1;
+	private static final int DEFAULT_PAGE_NUMBER = 0;
 	
 	static final Sliceable DEFAULT_SLICE_REQUEST = new SliceRequest(DEFAULT_PAGE_NUMBER, null, DEFAULT_MAX_PAGE_SIZE);
 	

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolver.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolver.java
@@ -33,8 +33,10 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import jp.xet.sparwings.spring.data.exceptions.InvalidSliceableException;
 import jp.xet.sparwings.spring.data.slice.SliceRequest;
 import jp.xet.sparwings.spring.data.slice.Sliceable;
+import jp.xet.sparwings.spring.web.httpexceptions.HttpBadRequestException;
 
 /**
  * Extracts paging information from web requests and thus allows injecting {@link Sliceable} instances into controller
@@ -171,7 +173,14 @@ public class SliceableHandlerMethodArgumentResolver implements HandlerMethodArgu
 				log.trace("invalid page number: {}", pageNumberString);
 			}
 		}
-		return new SliceRequest(pageNumber, direction, pageSize);
+		
+		Sliceable sliceable = new SliceRequest(pageNumber, direction, pageSize);
+		try {
+			sliceable.validate();
+		} catch (InvalidSliceableException e) {
+			throw new HttpBadRequestException(e.getMessage(), e);
+		}
+		return sliceable;
 	}
 	
 	private Sliceable getDefaultFromAnnotationOrFallback(MethodParameter methodParameter) {

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolver.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolver.java
@@ -162,7 +162,10 @@ public class SliceableHandlerMethodArgumentResolver implements HandlerMethodArgu
 		// Limit upper bound
 		pageSize = pageSize > maxPageSize ? maxPageSize : pageSize;
 		
-		Direction direction = Direction.fromOptionalString(directionString).orElse(null);
+		// Direction の優先度は
+		// 1. パラメータの direction
+		// 2. @SliceableDefault の direction
+		Direction direction = Direction.fromOptionalString(directionString).orElse(defaultOrFallback.getDirection());
 		
 		Integer pageNumber =
 				defaultOrFallback.getPageNumber() != null ? defaultOrFallback.getPageNumber() : DEFAULT_PAGE_NUMBER;

--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SpringDataSliceableAnnotationUtils.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/SpringDataSliceableAnnotationUtils.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.web;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+import lombok.experimental.UtilityClass;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.ObjectUtils;
+
+import jp.xet.sparwings.spring.data.slice.Slice;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+/**
+ * SliceableDefault に関する Utils.
+ */
+@UtilityClass
+class SpringDataSliceableAnnotationUtils {
+	
+	/**
+	 * Asserts uniqueness of all {@link Slice} parameters of the method of the given {@link MethodParameter}.
+	 * 
+	 * @param parameter must not be {@literal null}.
+	 */
+	public static void assertSliceableUniqueness(MethodParameter parameter) {
+		Method method = parameter.getMethod();
+		
+		if (method == null) {
+			throw new IllegalArgumentException("MethodParameter must has method");
+		}
+		
+		if (containsMoreThanOneSliceableParameter(method)) {
+			Annotation[][] annotations = method.getParameterAnnotations();
+			assertQualifiersFor(method.getParameterTypes(), annotations);
+		}
+	}
+	
+	/**
+	 * Returns whether the given {@link Method} has more than one {@link Sliceable} parameter.
+	 * 
+	 * @param method must not be {@literal null}.
+	 * @return Sliceable をパラメータにしている場合、true
+	 */
+	private static boolean containsMoreThanOneSliceableParameter(Method method) {
+		boolean sliceableFound = false;
+		for (Class<?> type : method.getParameterTypes()) {
+			if (sliceableFound && type.equals(Sliceable.class)) {
+				return true;
+			}
+			if (type.equals(Sliceable.class)) {
+				sliceableFound = true;
+			}
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * Returns the value of the given specific property of the given annotation. If the value of that property is the
+	 * properties default, we fall back to the value of the {@code value} attribute.
+	 * 
+	 * @param annotation must not be {@literal null}.
+	 * @param property must not be {@literal null} or empty.
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> T getSpecificPropertyOrDefaultFromValue(Annotation annotation, String property) {
+		Object propertyDefaultValue = AnnotationUtils.getDefaultValue(annotation, property);
+		Object propertyValue = AnnotationUtils.getValue(annotation, property);
+		
+		return (T) (ObjectUtils.nullSafeEquals(propertyDefaultValue, propertyValue)
+				? AnnotationUtils.getValue(annotation)
+				: propertyValue);
+	}
+	
+	/**
+	 * Asserts that every {@link Sliceable} parameter of the given parameters carries an {@link Qualifier} annotation to
+	 * distinguish them from each other.
+	 * 
+	 * @param parameterTypes must not be {@literal null}.
+	 * @param annotations must not be {@literal null}.
+	 */
+	public static void assertQualifiersFor(Class<?>[] parameterTypes, Annotation[][] annotations) { // NOPMD
+		Set<String> values = new HashSet<>();
+		for (int i = 0; i < annotations.length; i++) {
+			if (Sliceable.class.equals(parameterTypes[i])) {
+				Qualifier qualifier = findAnnotation(annotations[i]);
+				if (null == qualifier) {
+					throw new IllegalStateException("Ambiguous Sliceable arguments in handler method."
+							+ " If you use multiple parameters of type Sliceable"
+							+ " you need to qualify them with @Qualifier");
+				}
+				if (values.contains(qualifier.value())) {
+					throw new IllegalStateException("Values of the user Qualifiers must be unique!");
+				}
+				values.add(qualifier.value());
+			}
+		}
+	}
+	
+	/**
+	 * Returns a {@link Qualifier} annotation from the given array of {@link Annotation}s. Returns {@literal null} if the
+	 * array does not contain a {@link Qualifier} annotation.
+	 * 
+	 * @param annotations must not be {@literal null}.
+	 * @return
+	 */
+	public static Qualifier findAnnotation(Annotation... annotations) {
+		for (Annotation annotation : annotations) {
+			if (annotation instanceof Qualifier) {
+				return (Qualifier) annotation;
+			}
+		}
+		
+		return null;
+	}
+}

--- a/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/model/SlicedResourcesTest.java
+++ b/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/model/SlicedResourcesTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.domain.Sort;
+
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jp.xet.sparwings.spring.data.slice.Slice;
+import jp.xet.sparwings.spring.data.slice.SliceImpl;
+import jp.xet.sparwings.spring.data.slice.SliceRequest;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+/**
+ * Test for {@link SlicedResources}
+ */
+public class SlicedResourcesTest {
+	
+	private static final ObjectMapper OM = new ObjectMapper();
+	
+	
+	@Test
+	public void testToJsonString_ByStringList() throws Exception {
+		// setup
+		List<String> content = Arrays.asList("aaa", "bbb", "ccc");
+		Slice<String> slice = new SliceImpl<>(content, new SliceRequest(2, Sort.Direction.ASC, 10), false);
+		SlicedResources<String> stringsSliceResource = new SlicedResources<>("strings", slice);
+		
+		// exercise
+		String actual = OM.writeValueAsString(stringsSliceResource);
+		
+		// verify
+		String expectedJsonString = "{"
+				+ "  \"_embedded\": {"
+				+ "    \"strings\": ["
+				+ "      \"aaa\", \"bbb\", \"ccc\""
+				+ "    ]"
+				+ "  },"
+				+ "  \"page\": {"
+				+ "    \"size\": 3,"
+				+ "    \"number\": 2,"
+				+ "    \"has_next_page\": false"
+				+ "  }"
+				+ "}";
+		JSONAssert.assertEquals(actual, expectedJsonString, JSONCompareMode.STRICT);
+	}
+	
+	@Test
+	public void testToJsonString_ByBeanList() throws Exception {
+		// setup
+		List<SampleBean> content = Arrays.asList(new SampleBean("aaa", "bbb"), new SampleBean("ccc", "ddd"));
+		Slice<SampleBean> slice = new SliceImpl<>(content, new SliceRequest(7, Sort.Direction.ASC, 10), true);
+		SlicedResources<SampleBean> beansSliceResource = new SlicedResources<>("beans", slice);
+		
+		// exercise
+		String actual = OM.writeValueAsString(beansSliceResource);
+		
+		// verify
+		String expectedJsonString = "{"
+				+ "  \"_embedded\": {"
+				+ "    \"beans\": ["
+				+ "      {"
+				+ "        \"foo\": \"aaa\","
+				+ "        \"bar\": \"bbb\""
+				+ "      },"
+				+ "      {"
+				+ "        \"foo\": \"ccc\","
+				+ "        \"bar\": \"ddd\""
+				+ "      }"
+				+ "    ]"
+				+ "  },"
+				+ "  \"page\": {"
+				+ "    \"size\": 2,"
+				+ "    \"number\": 7,"
+				+ "    \"has_next_page\": true"
+				+ "  }"
+				+ "}";
+		JSONAssert.assertEquals(actual, expectedJsonString, JSONCompareMode.STRICT);
+	}
+	
+	@Test
+	public void testConstructorWithWrapperFunction() {
+		// setup
+		List<String> content = Arrays.asList("100", "102", "404");
+		Sliceable sliceable = new SliceRequest(2, Sort.Direction.ASC, 10);
+		Slice<String> slice = new SliceImpl<>(content, sliceable, true);
+		Function<String, Integer> wrapperFunction = Integer::parseInt;
+		
+		// exercise
+		SlicedResources<Integer> actual = new SlicedResources<>("elements", slice, wrapperFunction);
+		
+		// verify
+		List<Integer> expectedContent = Arrays.asList(100, 102, 404);
+		Slice<Integer> expectedSlice = new SliceImpl<>(expectedContent, sliceable, true);
+		SlicedResources<Integer> expected = new SlicedResources<>("elements", expectedSlice);
+		assertThat(actual, is(expected));
+	}
+	
+	@Test
+	public void testConstructor() {
+		// setup
+		List<String> content = Arrays.asList("100", "102", "404");
+		
+		// exercise
+		SlicedResources<String> actual = new SlicedResources<>("elements", content);
+		
+		// verify
+		SlicedResources<String> expected = new SlicedResources<>("elements", content,
+				new SlicedResources.SliceMetadata(content.size(), null, false));
+		assertThat(actual, is(expected));
+	}
+	
+	
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@SuppressWarnings("javadoc")
+	public static class SampleBean {
+		
+		private String foo;
+		
+		private String bar;
+	}
+}

--- a/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/slice/SliceImplTest.java
+++ b/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/slice/SliceImplTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.slice;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.domain.Sort;
+
+import org.junit.Test;
+
+/**
+ * Test for {@link SliceImpl}
+ */
+public class SliceImplTest {
+	
+	@Test
+	public void testNextSlice() {
+		// setup
+		List<String> content = Arrays.asList("abc", "def");
+		Sliceable sliceable = new SliceRequest(3, Sort.Direction.DESC, 30);
+		Slice<String> sut = new SliceImpl<>(content, sliceable, true);
+		
+		// exercise
+		Sliceable actual = sut.nextSlice();
+		
+		// verify
+		Sliceable expected = new SliceRequest(4, // ページ数インクリメント
+				Sort.Direction.DESC, 30);
+		assertThat(actual, is(expected));
+	}
+	
+	@Test
+	public void testNextSlice_NotNextSlice() {
+		// setup
+		List<String> content = Arrays.asList("abc", "def");
+		Sliceable sliceable = new SliceRequest(3, Sort.Direction.DESC, 30);
+		Slice<String> sut = new SliceImpl<>(content, sliceable, false);
+		
+		// exercise
+		Sliceable actual = sut.nextSlice();
+		
+		// verify
+		assertThat(actual, is(nullValue()));
+	}
+	
+	@Test
+	public void testMap() {
+		// setup
+		List<String> content = Arrays.asList("456", "123");
+		Sliceable sliceable = new SliceRequest(3, Sort.Direction.DESC, 30);
+		Slice<String> sut = new SliceImpl<>(content, sliceable, false);
+		Converter<String, Integer> converter = Integer::parseInt;
+		
+		// exercise
+		Slice<Integer> actual = sut.map(converter);
+		
+		// verify
+		List<Integer> expectedContent = Arrays.asList(456, 123);
+		Slice<Integer> expected = new SliceImpl<>(expectedContent, sliceable, false);
+		assertThat(actual, is(expected));
+	}
+}

--- a/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/slice/SliceRequestTest.java
+++ b/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/slice/SliceRequestTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.slice;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.springframework.data.domain.Sort;
+
+import org.junit.Test;
+
+/**
+ * Test for {@link SliceRequest}
+ */
+public class SliceRequestTest {
+	
+	@Test
+	public void testGetOffset() {
+		// setup
+		SliceRequest sut = new SliceRequest(3, Sort.Direction.ASC, 14);
+		
+		// exercise
+		Integer actual = sut.getOffset();
+		
+		// verify
+		assertThat(actual, is((3 - 1) * 14));
+	}
+	
+	@Test
+	public void testGetOffset_NullValue() {
+		// setup
+		SliceRequest sut = new SliceRequest(null, Sort.Direction.ASC, null);
+		
+		// exercise
+		Integer actual = sut.getOffset();
+		
+		// verify
+		assertThat(actual, is(nullValue()));
+	}
+}

--- a/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/slice/SliceRequestTest.java
+++ b/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/slice/SliceRequestTest.java
@@ -37,7 +37,19 @@ public class SliceRequestTest {
 		Integer actual = sut.getOffset();
 		
 		// verify
-		assertThat(actual, is((3 - 1) * 14));
+		assertThat(actual, is(3 * 14));
+	}
+	
+	@Test
+	public void testGetOffset_ZeroPageNumber() {
+		// setup
+		SliceRequest sut = new SliceRequest(0, Sort.Direction.ASC, 14);
+		
+		// exercise
+		Integer actual = sut.getOffset();
+		
+		// verify
+		assertThat(actual, is(0)); // 0 * 14
 	}
 	
 	@Test

--- a/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolverTest.java
+++ b/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolverTest.java
@@ -1,0 +1,546 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.spring.data.web;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import org.junit.Test;
+
+import jp.xet.sparwings.spring.data.slice.SliceRequest;
+import jp.xet.sparwings.spring.data.slice.Sliceable;
+
+/**
+ * Test for {@link SliceableHandlerMethodArgumentResolver}.
+ */
+@SuppressWarnings("javadoc")
+public class SliceableHandlerMethodArgumentResolverTest {
+	
+	SliceableHandlerMethodArgumentResolver sut = new SliceableHandlerMethodArgumentResolver();
+	
+	
+	public void simpleHandler(Sliceable sliceable) {
+		// nothing to do
+	}
+	
+	@Test
+	public void testSimpleHandler() throws Exception {
+		// setup
+		Method method = getClass().getMethod("simpleHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		assertThat(actual, is(sut.getFallbackSliceable()));
+	}
+	
+	public void defaultHandler(@SliceableDefault Sliceable sliceable) {
+		// nothing to do
+	}
+	
+	@Test
+	public void testDefaultHandler() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, Direction.ASC, 10);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	public void defaultHandlerWithValue(@SliceableDefault(size = 123) Sliceable sliceable) {
+		// nothing to do
+	}
+	
+	@Test
+	public void testDefaultHandlerWithValue() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandlerWithValue", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, Direction.ASC, 123);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	public void multipleSliceable(Sliceable c1, Sliceable c2) {
+		// nothing to do
+	}
+	
+	@Test(expected = IllegalStateException.class)
+	public void testMultipleSliceable() throws Exception {
+		// setup
+		Method method = getClass().getMethod("multipleSliceable", Sliceable.class, Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// assert exception
+		fail();
+	}
+	
+	@Test
+	public void testSimpleHandlerWithSizeParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("simpleHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("123");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, null, 123);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testDefaultHandlerWithSizeParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("123");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, null, 123);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testDefaultHandlerWithValueWithSizeParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandlerWithValue", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("123");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, null, 123);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testSimpleHandlerWithExceededSizeParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("simpleHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("12345");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, null, 2000); // 2000 を超えないこと
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testDefaultHandlerWithExceededSizeParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("12345");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, null, 2000); // 2000 を超えないこと
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testNegativeSize() throws Exception {
+		// setup
+		Method method = getClass().getMethod("simpleHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("-1");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, null, 1); // 強制的に 1
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testSimpleHandlerWithIllegalSizeParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("simpleHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("foo");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, null, 2000); // 強制的に 2000
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testDefaultHandlerWithIllegalSizeParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("foo");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, null, 10); // 強制的に 10
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testDefaultHandlerWithValueWithIllegalSizeParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandlerWithValue", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("foo");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, null, 123); // 強制的に default 値
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testDefaultHandlerWithValueWithPageNumberParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("simpleHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("page_number"))).thenReturn("100");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(100, null, 2000);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testDefaultHandlerWithValueWithIllegalPageNumberParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("simpleHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("page_number"))).thenReturn("foo");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, null, 2000);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testPageNumberAndSize() throws Exception {
+		// setup
+		Method method = getClass().getMethod("simpleHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("10");
+		when(webRequest.getParameter(eq("page_number"))).thenReturn("101");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(101, null, 10);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testDirection() throws Exception {
+		Method method = getClass().getMethod("simpleHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("direction"))).thenReturn("DESC");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, Direction.DESC, 2000);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testIllegalDirection() throws Exception {
+		// setup
+		Method method = getClass().getMethod("simpleHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("direction"))).thenReturn("FOO");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, null, 2000);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testFull() throws Exception {
+		// setup
+		Method method = getClass().getMethod("simpleHandler", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("12");
+		when(webRequest.getParameter(eq("page_number"))).thenReturn("13");
+		when(webRequest.getParameter(eq("direction"))).thenReturn("DESC");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(13, Direction.DESC, 12);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	public void defaultHandlerWithFullValue(
+			@SliceableDefault(size = 10, pageNumber = 2, direction = Direction.DESC) Sliceable sliceable) {
+		// nothing to do
+	}
+	
+	@Test
+	public void testDefaultHandlerWithFullValue() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandlerWithFullValue", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(2, Direction.DESC, 10);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testDefaultHandlerWithFullValue_WithParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandlerWithFullValue", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("3");
+		when(webRequest.getParameter(eq("page_number"))).thenReturn("345");
+		when(webRequest.getParameter(eq("direction"))).thenReturn("ASC");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(345, Direction.ASC, 3);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
+	public void testDefaultHandlerWithFullValue_WithInvalidParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandlerWithFullValue", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("size"))).thenReturn("a");
+		when(webRequest.getParameter(eq("page_number"))).thenReturn("b");
+		when(webRequest.getParameter(eq("direction"))).thenReturn("4649");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(2, null, 10);
+		assertThat(actualSliceable, is(expected));
+	}
+}

--- a/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolverTest.java
+++ b/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolverTest.java
@@ -89,7 +89,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, Direction.ASC, 10);
+		Sliceable expected = new SliceRequest(0, Direction.ASC, 10);
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -114,7 +114,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, Direction.ASC, 123);
+		Sliceable expected = new SliceRequest(0, Direction.ASC, 123);
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -156,7 +156,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, null, 123);
+		Sliceable expected = new SliceRequest(0, null, 123);
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -178,7 +178,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, null, 123);
+		Sliceable expected = new SliceRequest(0, null, 123);
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -200,7 +200,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, null, 123);
+		Sliceable expected = new SliceRequest(0, null, 123);
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -222,7 +222,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, null, 2000); // 2000 を超えないこと
+		Sliceable expected = new SliceRequest(0, null, 2000); // 2000 を超えないこと
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -244,7 +244,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, null, 2000); // 2000 を超えないこと
+		Sliceable expected = new SliceRequest(0, null, 2000); // 2000 を超えないこと
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -266,7 +266,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, null, 1); // 強制的に 1
+		Sliceable expected = new SliceRequest(0, null, 1); // 強制的に 1
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -288,7 +288,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, null, 2000); // 強制的に 2000
+		Sliceable expected = new SliceRequest(0, null, 2000); // 強制的に 2000
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -310,7 +310,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, null, 10); // 強制的に 10
+		Sliceable expected = new SliceRequest(0, null, 10); // 強制的に 10
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -332,7 +332,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, null, 123); // 強制的に default 値
+		Sliceable expected = new SliceRequest(0, null, 123); // 強制的に default 値
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -376,7 +376,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, null, 2000);
+		Sliceable expected = new SliceRequest(0, null, 2000);
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -420,7 +420,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, Direction.DESC, 2000);
+		Sliceable expected = new SliceRequest(0, Direction.DESC, 2000);
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -442,7 +442,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(1, null, 2000);
+		Sliceable expected = new SliceRequest(0, null, 2000);
 		assertThat(actualSliceable, is(expected));
 	}
 	

--- a/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolverTest.java
+++ b/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/web/SliceableHandlerMethodArgumentResolverTest.java
@@ -180,7 +180,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(0, null, 123);
+		Sliceable expected = new SliceRequest(0, Direction.ASC, 123);
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -202,7 +202,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(0, null, 123);
+		Sliceable expected = new SliceRequest(0, Direction.ASC, 123);
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -246,7 +246,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(0, null, 2000); // 2000 を超えないこと
+		Sliceable expected = new SliceRequest(0, Direction.ASC, 2000); // 2000 を超えないこと
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -312,7 +312,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(0, null, 10); // 強制的に 10
+		Sliceable expected = new SliceRequest(0, Direction.ASC, 10); // 強制的に 10
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -334,7 +334,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(0, null, 123); // 強制的に default 値
+		Sliceable expected = new SliceRequest(0, Direction.ASC, 123); // 強制的に default 値
 		assertThat(actualSliceable, is(expected));
 	}
 	
@@ -543,6 +543,28 @@ public class SliceableHandlerMethodArgumentResolverTest {
 	}
 	
 	@Test
+	public void testDefaultHandlerWithFullValue_WithOneParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandlerWithFullValue", Sliceable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("page_number"))).thenReturn("1");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Sliceable.class)));
+		Sliceable actualSliceable = (Sliceable) actual;
+		
+		Sliceable expected = new SliceRequest(1, Direction.DESC, 10);
+		assertThat(actualSliceable, is(expected));
+	}
+	
+	@Test
 	public void testDefaultHandlerWithFullValue_WithInvalidParameter() throws Exception {
 		// setup
 		Method method = getClass().getMethod("defaultHandlerWithFullValue", Sliceable.class);
@@ -562,7 +584,7 @@ public class SliceableHandlerMethodArgumentResolverTest {
 		assertThat(actual, is(instanceOf(Sliceable.class)));
 		Sliceable actualSliceable = (Sliceable) actual;
 		
-		Sliceable expected = new SliceRequest(2, null, 10);
+		Sliceable expected = new SliceRequest(2, Direction.DESC, 10);
 		assertThat(actualSliceable, is(expected));
 	}
 }


### PR DESCRIPTION
# 概要

#2 

# 内容
Service / Repository 向け
(実際に SQL を意識するのは spring-data-mirage 側の PR を参照)

* SliceableRepository
  * この PR のメイン
  * この interface を implement すると Slice を取得する SQL が発行可能
* Slice
  * Slice 形式の SQL 発行結果を保持する interface
  * 実装は SliceImpl
* Sliceable
  * SQL 発行時のパラメータの interface
  * 実装は SliceRequest

Controller 向け

* SlicedResources
  * Controller 側で意識する Value Object
  * レスポンス JSON の構成情報(Chunk で返す場合の ChunkedResources 相当)
* SliceableDefault
  * Controller のメソッドのパラメータとして設定するアノテーション(Chunk のパラメータを受け取る場合の `@ChunkableDefault` 相当)
  * デフォルト size=10, direction=ASC, page_number=0
* SliceableHandlerMethodArgumentResolver
  * Controller のリクエストを元に Sliceable インスタンスを生成する
  * WebMvcConfigurer の実装クラスで追加する必要がある
  * SpringDataSliceableAnnotationUtils はその Utils

