### PR TITLE
SNSのメッセージにMessageAttributeを指定

### DIFF
--- a/spar-wings-event/src/main/java/jp/xet/sparwings/event/SWEvent.java
+++ b/spar-wings-event/src/main/java/jp/xet/sparwings/event/SWEvent.java
@@ -37,8 +37,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
- * TODO for daisuke
- * 
+ * SNS のイベント通知自体を表すクラス
+ *
+ * <p>本クラスをシリアライズした値が SWEventListener によって SNS に通知される</p>
+ *
  * @since 0.16
  * @author daisuke
  */


### PR DESCRIPTION
すべてのイベントについてevent_typeをMessageAttributeとして指定するよう修正

https://docs.aws.amazon.com/ja_jp/sns/latest/dg/sns-subscription-filter-policies.html#string-value-matching
> Amazon SNS がサブスクリプションフィルタポリシーに対してメッセージ属性を評価する際に、ポリシーに指定されていないメッセージ属性は無視されます。

なので、既存のサブスクリプションに関しては壊れないと判断

https://docs.aws.amazon.com/ja_jp/sns/latest/dg/sns-message-attributes.html
> 値 – ユーザー指定のメッセージ属性値。文字列データ型の場合、値属性のコンテンツにはメッセージ本文と同じ制限があります。詳細については、『Amazon Simple Notification Service API Reference』の「Publish」アクションを参照してください。

なので、ペイロードにも入ってくるevent_typeは文字列の制限に引っかからないと判断

動作確認とドキュメントについては以下を参照
https://metropolis.esa.io/posts/6431