### PR TITLE
クエリパラメータで size / next / prev のいずれかを指定した場合 Chunkable インスタンスの direction を `@ChunkableDefault` の値に設定する

### DIFF
--- a/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/ChunkableHandlerMethodArgumentResolver.java
+++ b/spar-wings-spring-data-chunk/src/main/java/jp/xet/sparwings/spring/data/web/ChunkableHandlerMethodArgumentResolver.java
@@ -187,7 +187,7 @@ public class ChunkableHandlerMethodArgumentResolver implements HandlerMethodArgu
 		// Limit upper bound
 		pageSize = pageSize > maxPageSize ? maxPageSize : pageSize;
 		
-		Direction direction = Direction.fromOptionalString(directionString).orElse(null);
+		Direction direction = Direction.fromOptionalString(directionString).orElse(defaultOrFallback.getDirection());
 		
 		if (StringUtils.hasText(next)) {
 			return new ChunkRequest(next, PaginationRelation.NEXT, pageSize, direction);

--- a/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/web/ChunkableHandlerMethodArgumentResolverTest.java
+++ b/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/web/ChunkableHandlerMethodArgumentResolverTest.java
@@ -185,7 +185,7 @@ public class ChunkableHandlerMethodArgumentResolverTest {
 		assertThat(actualChunkable.getPaginationRelation(), is(nullValue()));
 		assertThat(actualChunkable.getPaginationToken(), is(nullValue()));
 		assertThat(actualChunkable.getMaxPageSize(), is(123));
-		assertThat(actualChunkable.getDirection(), is(nullValue()));
+		assertThat(actualChunkable.getDirection(), is(Direction.ASC)); // ChunkableDefault の direction の初期値は ASC
 	}
 	
 	@Test
@@ -207,7 +207,7 @@ public class ChunkableHandlerMethodArgumentResolverTest {
 		assertThat(actualChunkable.getPaginationRelation(), is(nullValue()));
 		assertThat(actualChunkable.getPaginationToken(), is(nullValue()));
 		assertThat(actualChunkable.getMaxPageSize(), is(123));
-		assertThat(actualChunkable.getDirection(), is(nullValue()));
+		assertThat(actualChunkable.getDirection(), is(Direction.ASC)); // ChunkableDefault の direction の初期値は ASC
 	}
 	
 	@Test
@@ -251,7 +251,7 @@ public class ChunkableHandlerMethodArgumentResolverTest {
 		assertThat(actualChunkable.getPaginationRelation(), is(nullValue()));
 		assertThat(actualChunkable.getPaginationToken(), is(nullValue()));
 		assertThat(actualChunkable.getMaxPageSize(), is(2000));
-		assertThat(actualChunkable.getDirection(), is(nullValue()));
+		assertThat(actualChunkable.getDirection(), is(Direction.ASC)); // ChunkableDefault の direction の初期値は ASC
 	}
 	
 	@Test
@@ -317,7 +317,7 @@ public class ChunkableHandlerMethodArgumentResolverTest {
 		assertThat(actualChunkable.getPaginationRelation(), is(nullValue()));
 		assertThat(actualChunkable.getPaginationToken(), is(nullValue()));
 		assertThat(actualChunkable.getMaxPageSize(), is(10));
-		assertThat(actualChunkable.getDirection(), is(nullValue()));
+		assertThat(actualChunkable.getDirection(), is(Direction.ASC)); // ChunkableDefault の direction の初期値は ASC
 	}
 	
 	@Test
@@ -339,7 +339,7 @@ public class ChunkableHandlerMethodArgumentResolverTest {
 		assertThat(actualChunkable.getPaginationRelation(), is(nullValue()));
 		assertThat(actualChunkable.getPaginationToken(), is(nullValue()));
 		assertThat(actualChunkable.getMaxPageSize(), is(123));
-		assertThat(actualChunkable.getDirection(), is(nullValue()));
+		assertThat(actualChunkable.getDirection(), is(Direction.ASC)); // ChunkableDefault の direction の初期値は ASC
 	}
 	
 	@Test
@@ -476,4 +476,130 @@ public class ChunkableHandlerMethodArgumentResolverTest {
 		assertThat(actualChunkable.getMaxPageSize(), is(10));
 		assertThat(actualChunkable.getDirection(), is(Direction.DESC));
 	}
+	
+	// direction に初期値を指定した時の振る舞い
+	
+	public void defaultHandlerWithInitValue(
+			@ChunkableDefault(size = 12, direction = Direction.DESC) Chunkable chunkable) {
+		// nothing to do
+	}
+	
+	/**
+	 * size と next 指定.
+	 * @throws Exception 例外
+	 */
+	@Test
+	public void testDefaultHandlerWithInitValue_WithSizeNextParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandlerWithInitValue", Chunkable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		// size と next 指定
+		when(webRequest.getParameter(eq("size"))).thenReturn("1234");
+		when(webRequest.getParameter(eq("next"))).thenReturn("next_token");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Chunkable.class)));
+		Chunkable actualChunkable = (Chunkable) actual;
+		
+		assertThat(actualChunkable.getPaginationRelation(), is(PaginationRelation.NEXT));
+		assertThat(actualChunkable.getPaginationToken(), is("next_token"));
+		assertThat(actualChunkable.getMaxPageSize(), is(1234));
+		// defaultHandlerWithInitValue に付与した ChunkableDefault の direction の初期値は DESC
+		assertThat(actualChunkable.getDirection(), is(Direction.DESC));
+	}
+	
+	/**
+	 * prev と direction 指定.
+	 * @throws Exception 例外
+	 */
+	@Test
+	public void testDefaultHandlerWithInitValue_WithPrevDirectionParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandlerWithInitValue", Chunkable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		// size と next 指定
+		when(webRequest.getParameter(eq("direction"))).thenReturn(Direction.DESC.name());
+		when(webRequest.getParameter(eq("prev"))).thenReturn("prev_token");
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Chunkable.class)));
+		Chunkable actualChunkable = (Chunkable) actual;
+		
+		assertThat(actualChunkable.getPaginationRelation(), is(PaginationRelation.PREV));
+		assertThat(actualChunkable.getPaginationToken(), is("prev_token"));
+		assertThat(actualChunkable.getMaxPageSize(), is(12));
+		assertThat(actualChunkable.getDirection(), is(Direction.DESC));
+	}
+	
+	/**
+	 * direction 指定.
+	 * @throws Exception 例外
+	 */
+	@Test
+	public void testDefaultHandlerWithInitValue_WithDirectionParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandlerWithInitValue", Chunkable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		when(webRequest.getParameter(eq("direction"))).thenReturn(Direction.ASC.name());
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Chunkable.class)));
+		Chunkable actualChunkable = (Chunkable) actual;
+		
+		assertThat(actualChunkable.getPaginationRelation(), is(nullValue()));
+		assertThat(actualChunkable.getPaginationToken(), is(nullValue()));
+		assertThat(actualChunkable.getMaxPageSize(), is(12));
+		assertThat(actualChunkable.getDirection(), is(Direction.ASC));
+	}
+	
+	/**
+	 * クエリパラメータ未指定.
+	 * 
+	 * @throws Exception 例外
+	 */
+	@Test
+	public void testDefaultHandlerWithInitValue_NoParameter() throws Exception {
+		// setup
+		Method method = getClass().getMethod("defaultHandlerWithInitValue", Chunkable.class);
+		MethodParameter methodParametere = new MethodParameter(method, 0);
+		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+		NativeWebRequest webRequest = mock(NativeWebRequest.class);
+		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+		
+		// exercise
+		Object actual = sut.resolveArgument(methodParametere, mavContainer, webRequest, binderFactory);
+		
+		// verify
+		assertThat(actual, is(notNullValue()));
+		assertThat(actual, is(instanceOf(Chunkable.class)));
+		Chunkable actualChunkable = (Chunkable) actual;
+		
+		// `@ChunkableDefault` の初期値が使用される
+		assertThat(actualChunkable.getPaginationRelation(), is(nullValue()));
+		assertThat(actualChunkable.getPaginationToken(), is(nullValue()));
+		assertThat(actualChunkable.getMaxPageSize(), is(12));
+		assertThat(actualChunkable.getDirection(), is(Direction.DESC));
+	}
+	
 }

--- a/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/web/ChunkableHandlerMethodArgumentResolverTest.java
+++ b/spar-wings-spring-data-chunk/src/test/java/jp/xet/sparwings/spring/data/web/ChunkableHandlerMethodArgumentResolverTest.java
@@ -526,7 +526,7 @@ public class ChunkableHandlerMethodArgumentResolverTest {
 		MethodParameter methodParametere = new MethodParameter(method, 0);
 		ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
 		NativeWebRequest webRequest = mock(NativeWebRequest.class);
-		// size と next 指定
+		// prev と direction 指定
 		when(webRequest.getParameter(eq("direction"))).thenReturn(Direction.DESC.name());
 		when(webRequest.getParameter(eq("prev"))).thenReturn("prev_token");
 		WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);


### PR DESCRIPTION
# 内容

See #50 

`@ChunkableDefault(size = 10, direction = Sort.Direction.DESC)` を設定している時、

* クエリパラメータで size / next / prev 何も指定していなければ Chunkable インスタンスの direction は DESC

なのに

* クエリパラメータで size / next / prev のいずれかを指定していると Chunkable インスタンスの direction は null

なのはおかしいので修正。

spring-data-mirage の場合、direction が null の場合 ASC 扱いとしているので問題にはなっていないが、direction の初期値の扱いが明らかにおかしい。
(direction が未指定の場合に使用する値となるべき)

# この対応で発生しうる不具合

## ケース1

`@ChunkableDefault(size = 10, direction = Sort.Direction.DESC)` を指定した時に
クエリパラメータで size / next / prev のいずれかを指定していると Chunkable インスタンスの direction は null
を期待している処理が存在する場合

↓

そんな期待するのは矛盾していると思われるし、現在の Pz で `@ChunkableDefault` の direction を指定しているのは1つだけだったので問題無しと判断。
(braking-change ではない筈)

## ケース2

`@ChunkableDefault` を指定した時(初期値の変更無し)に
クエリパラメータで size の指定をして、Chunkable インスタンスの direction に null
を期待している処理が存在する場合(対応後は ASC が設定されてしまうのでエラーになる)

↓

spring-data-mirage の場合、direction が null の場合 ASC 扱いとしているので問題ない筈。
クエリパラメータに ASC 指定された時に direction には ASC が指定されるので ASC での動作確認は行っているハズ。

むしろ既存の振る舞いを受け入れているのに ASC の対応をしていない方がおかしい。
