### PR TITLE
OncePerRequestFilterを継承を削除

### DIFF
--- a/spar-wings-aws-logging/src/main/java/jp/xet/sparwings/aws/ec2/ExtendedMDCInsertingServletFilter.java
+++ b/spar-wings-aws-logging/src/main/java/jp/xet/sparwings/aws/ec2/ExtendedMDCInsertingServletFilter.java
@@ -17,16 +17,15 @@ package jp.xet.sparwings.aws.ec2;
 
 import java.io.IOException;
 
+import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import lombok.Getter;
 import lombok.Setter;
-
-import org.springframework.web.filter.OncePerRequestFilter;
 
 import org.slf4j.MDC;
 
@@ -39,7 +38,7 @@ import org.slf4j.MDC;
  * @author daisuke
  * @see ch.qos.logback.classic.helpers.MDCInsertingServletFilter
  */
-public class ExtendedMDCInsertingServletFilter extends OncePerRequestFilter {
+public class ExtendedMDCInsertingServletFilter implements Filter {
 	
 	static final String REQUEST_REMOTE_HOST_MDC_KEY = "remoteHost";
 	
@@ -66,9 +65,8 @@ public class ExtendedMDCInsertingServletFilter extends OncePerRequestFilter {
 	}
 	
 	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-			throws ServletException, IOException {
-		
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
+			throws IOException, ServletException {
 		try {
 			insertIntoMDC(request);
 			filterChain.doFilter(request, response);

--- a/spar-wings-request-id/src/main/java/jp/xet/sparwings/common/filters/RequestIdLogFilter.java
+++ b/spar-wings-request-id/src/main/java/jp/xet/sparwings/common/filters/RequestIdLogFilter.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.common.filters;
+
+import java.io.IOException;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.slf4j.MDC;
+
+/**
+ * Servlet {@link Filter} implementation to generate Request-ID.
+ * 
+ * <p>Generated Request-ID is set to {@code X-Request-Id} response header
+ * and {@link MDC} value which identified by {@code requestId}.
+ * If requestId already exists in request attributes, use it</p>
+ *
+ * @see RequestIdFilter
+ * @author kawano
+ */
+@Slf4j
+public class RequestIdLogFilter implements Filter {
+	
+	private static final String DEFAULT_REQUEST_ID_ATTRIBUTE = "requestId";
+	
+	private static final String DEFAULT_REQUEST_ID_HEADER = "Request-Id";
+	
+	private static final String DEFAULT_REQUEST_ID_MDC_KEY = "requestId";
+	
+	@Getter
+	@Setter
+	private String requestIdAttribute = DEFAULT_REQUEST_ID_ATTRIBUTE;
+	
+	@Getter
+	@Setter
+	private String requestIdMdcKey = DEFAULT_REQUEST_ID_MDC_KEY;
+	
+	@Getter
+	@Setter
+	private String requestIdHeader = DEFAULT_REQUEST_ID_HEADER;
+	
+	@NonNull
+	@Getter
+	@Setter
+	private RequestIdGenerator generator = new UuidRequestIdGenerator();
+	
+	
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		
+		if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
+			throw new ServletException("RequestIdLogFilter just supports HTTP requests");
+		}
+		HttpServletRequest httpRequest = (HttpServletRequest) request;
+		HttpServletResponse httpResponse = (HttpServletResponse) response;
+		
+		doFilterInternal(httpRequest, httpResponse, chain);
+	}
+	
+	@Override
+	public void destroy() {
+		// nothing to do
+	}
+	
+	void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+		log.trace("Start issue request ID");
+		String requestId = generateRequestId(request);
+		if (requestId == null) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+		log.info("Request ID issued: {}", requestId);
+		if (requestIdAttribute != null) {
+			request.setAttribute(requestIdAttribute, requestId);
+		}
+		if (requestIdMdcKey != null) {
+			MDC.put(requestIdMdcKey, requestId);
+		}
+		if (requestIdHeader != null) {
+			response.setHeader(requestIdHeader, requestId);
+		}
+		try {
+			filterChain.doFilter(request, response);
+		} finally {
+			if (requestIdMdcKey != null) {
+				MDC.remove(requestIdMdcKey);
+			}
+		}
+	}
+	
+	private String generateRequestId(final HttpServletRequest request) {
+		final DispatcherType dispatcherType = request.getDispatcherType();
+		switch (dispatcherType) {
+			case FORWARD:
+			case INCLUDE:
+			case ASYNC:
+			case ERROR:
+				return (String) request.getAttribute(requestIdAttribute);
+			case REQUEST:
+			default:
+				return generator.generateRequestId(request);
+		}
+	}
+}

--- a/spar-wings-request-id/src/test/java/jp/xet/sparwings/common/filters/RequestIdLogFilterTest.java
+++ b/spar-wings-request-id/src/test/java/jp/xet/sparwings/common/filters/RequestIdLogFilterTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.common.filters;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.slf4j.MDC;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * RequestIdLogFilterTest
+ * <p>
+ *     RequestIdがMDCに登録されることをTest
+ * </p>
+ */
+@SuppressWarnings("javadoc")
+@RunWith(MockitoJUnitRunner.class)
+public class RequestIdLogFilterTest {
+	
+	RequestIdLogFilter sut;
+	
+	@Mock
+	HttpServletRequest request;
+	
+	@Mock
+	HttpServletResponse response;
+	
+	@Mock
+	RequestIdGenerator generator;
+	
+	static String MDC_KEY = "requestId";
+	
+	
+	@Before
+	public void setUp() {
+		sut = new RequestIdLogFilter();
+		sut.setGenerator(generator);
+	}
+	
+	@Test
+	public void testDispatcherType_REQUEST_generateId() throws IOException, ServletException {
+		// setup
+		String expectedRequestId = "56a89f35-0ad8-4c3f-9817-24537253a13c";
+		when(request.getDispatcherType()).thenReturn(DispatcherType.REQUEST);
+		when(generator.generateRequestId(any())).thenReturn(expectedRequestId);
+		
+		// exercise
+		sut.doFilter(request, response, new MDCLog(is(expectedRequestId)));
+		// verify
+		verify(request, never()).getAttribute(any());
+		verify(request, times(1)).setAttribute(eq(sut.getRequestIdAttribute()), eq(expectedRequestId));
+		verify(response, times(1)).setHeader(eq(sut.getRequestIdHeader()), eq(expectedRequestId));
+	}
+	
+	@Test
+	public void testDispatcherType_ASYNC_getAttribute_null() throws IOException, ServletException {
+		// setup
+		when(request.getDispatcherType()).thenReturn(DispatcherType.ASYNC);
+		when(request.getAttribute(any())).thenReturn(null);
+		
+		FilterChain filterChain = spy(new MDCLog(nullValue()));
+		// exercise
+		sut.doFilter(request, response, filterChain);
+		// verify
+		verify(request, times(1)).getAttribute(eq(MDC_KEY));
+		verify(filterChain, times(1)).doFilter(any(), any());
+		verify(request, never()).setAttribute(any(), any());
+		verify(response, never()).setHeader(any(), any());
+	}
+	
+	@Test
+	public void testDispatcherType_ASYNC_getAttribute() throws IOException, ServletException {
+		// setup
+		String expectedRequestId = "testRequestId";
+		when(request.getDispatcherType()).thenReturn(DispatcherType.ASYNC);
+		when(request.getAttribute(any())).thenReturn(expectedRequestId);
+		// exercise
+		sut.doFilter(request, response, new MDCLog(Matchers.is(expectedRequestId)));
+		// verify
+		verify(request, times(1)).getAttribute(eq(MDC_KEY));
+		verify(request, times(1)).setAttribute(eq(sut.getRequestIdAttribute()), eq(expectedRequestId));
+		verify(response, times(1)).setHeader(eq(sut.getRequestIdHeader()), eq(expectedRequestId));
+	}
+	
+	
+	@AllArgsConstructor
+	@Slf4j
+	static class MDCLog implements FilterChain {
+		
+		Matcher<Object> expected;
+		
+		
+		@Override
+		public void doFilter(ServletRequest request, ServletResponse response) {
+			assertThat(MDC.get(MDC_KEY), expected);
+		}
+	}
+}

--- a/spar-wings-spring-security-essential/src/main/java/jp/xet/sparwings/spring/security/UsernameLogFilter.java
+++ b/spar-wings-spring-security-essential/src/main/java/jp/xet/sparwings/spring/security/UsernameLogFilter.java
@@ -20,13 +20,13 @@ import java.io.IOException;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.util.StringUtils;
 
 import org.slf4j.MDC;
 
@@ -36,7 +36,7 @@ import org.slf4j.MDC;
  * @since 0.3
  * @author daisuke
  */
-public class UsernameLogFilter extends OncePerRequestFilter {
+public class UsernameLogFilter implements Filter {
 	
 	private static final String USER_KEY = "username";
 	
@@ -47,8 +47,8 @@ public class UsernameLogFilter extends OncePerRequestFilter {
 	}
 	
 	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-			throws ServletException, IOException {
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
+			throws IOException, ServletException {
 		SecurityContext ctx = SecurityContextHolder.getContext();
 		Authentication auth = ctx.getAuthentication();
 		
@@ -74,7 +74,7 @@ public class UsernameLogFilter extends OncePerRequestFilter {
 	 * @return true id the user can be successfully registered
 	 */
 	private boolean registerUsername(String username) {
-		if (username != null && username.trim().isEmpty() == false) {
+		if (StringUtils.hasText(username)) {
 			MDC.put(USER_KEY, username);
 			return true;
 		}


### PR DESCRIPTION
# 内容
DispatcherTypeでASYNCやERRORでも同じようにMDCに記録してほしいが一回だけの保証しているので、
OncePerRequestFilterを継承させないことで複数回呼び出し可能に対応。
RequestIdFilterだけはリクエスト内で同一の値である必要がある。
他は呼び出しのたびに記録しても同じ値になる想定。

breaking changeになると思われるが大丈夫か


### RequestIdLogFilter
* DispatcherType.REQUESTの時はIDを作成し、それ以外はRequestのattributeから取得するように修正
* 別クラスとして作成(処理が大きく変わるので)
### UsernameLogFilter =>SimpleUsernameLogFilter?(別名案)
* OncePerRequestFilterの継承削除してFilterを実装するだけ（処理内容自体は変更しないため）
* 別クラスとして定義すべきか悩み

### ExtendedMDCInsertingServletFilter => RequestLogFilter?(別名案)
* OncePerRequestFilterの継承削除してFilterを実装するだけ（処理内容自体は変更しないため）
* 別クラスとして定義すべきか悩み
